### PR TITLE
fix(#48): 소켓 통신 케이스 수정/ 조정 페이지/ 채팅 페이지 디테일 디벨롭

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ declare global {
     setKioskMode: (mode: string) => void;
     getKioskMode: () => string;
     setLock: () => void;
+    showButton: (mode: boolean) => void;
   }
 }
 const App = () => {

--- a/src/components/InactivityWatcher.tsx
+++ b/src/components/InactivityWatcher.tsx
@@ -25,8 +25,8 @@ const InactivityWatcher = () => {
   // false가 된 순간에만 1번 실행
   useEffect(() => {
     if (!isLocked) {
-      sendMessage({ type: "PIR_ON" }); //CASE 2-2
-      console.log("잠금해제");
+      sendMessage({ type: "PIR_OFF" }); //CASE 2-2
+      console.log("잠금해제/라즈베리파이에게 PIR_OFF 전송");
     }
   }, [isLocked, sendMessage]);
 

--- a/src/components/LockScreen.tsx
+++ b/src/components/LockScreen.tsx
@@ -2,25 +2,25 @@ import styled from "styled-components";
 import { useLockStore } from "../stores/lockStore";
 import IncluKioskSub from "../assets/imgs/IncluKioskSub.png";
 import { useEffect } from "react";
-import { useSocketStore } from "../stores/socketStore";
+import { SocketMessage, useSocketStore } from "../stores/socketStore";
 
 const LockScreen = () => {
   const { isLocked, setLocked, resetTimer } = useLockStore();
-  const { sendMessage, setOnMessage } = useSocketStore();
+  const { sendMessage, addOnMessage, removeOnMessage } = useSocketStore();
 
   useEffect(() => {
     if (isLocked) sendMessage({ type: "PIR_ON" }); //CASE 1
 
     //CASE 2-1
-    setOnMessage((msg) => {
+    const handle = (msg: SocketMessage) => {
       if (msg.type === "PIR_DETECTED") {
         setLocked(false); // 플래그 → 잠금 해제
         resetTimer();
       }
-    });
-
-    return () => setOnMessage(null);
-  }, [isLocked]);
+    };
+    addOnMessage(handle);
+    return () => removeOnMessage(handle);
+  }, [isLocked, addOnMessage, removeOnMessage]);
 
   return (
     <Overlay visible={isLocked}>

--- a/src/page/AdjustScreen/AdjustHeight.tsx
+++ b/src/page/AdjustScreen/AdjustHeight.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import styled, { keyframes } from "styled-components";
-import { useSocketStore } from "../../stores/socketStore";
+import { SocketMessage, useSocketStore } from "../../stores/socketStore";
 import kioskTop from "../../assets/imgs/kioskTop.webp";
 import kioskBottom from "../../assets/imgs/kioskBottom.webp";
 
 const AdjustHeight = ({ nextPage }: { nextPage: () => void }) => {
-  const { connect, setOnMessage } = useSocketStore();
+  const { connect, addOnMessage, removeOnMessage } = useSocketStore();
   const [currentStep, setCurrentStep] = useState(0);
   const [isAdjusting, setIsAdjusting] = useState(true);
 
@@ -22,16 +22,17 @@ const AdjustHeight = ({ nextPage }: { nextPage: () => void }) => {
   }, [connect]);
 
   useEffect(() => {
-    //CASE 3
-    setOnMessage((msg) => {
+    const handle = (msg: SocketMessage) => {
       if (msg.type === "EYE_CALIB_ON") {
         setIsAdjusting(false);
         setCurrentStep(3);
         setTimeout(() => nextPage(), 2000);
       }
-    });
-    return () => setOnMessage(null);
-  }, [setOnMessage, nextPage]);
+    };
+
+    addOnMessage(handle);
+    return () => removeOnMessage(handle);
+  }, [addOnMessage, removeOnMessage, nextPage]);
 
   // 문구 수정
   useEffect(() => {

--- a/src/page/Chat/Chat.tsx
+++ b/src/page/Chat/Chat.tsx
@@ -13,7 +13,8 @@ interface ChatMessage {
 }
 
 const Chat = () => {
-  const { connect, sendMessage, setOnMessage, isConnected } = useSocketStore();
+  const { connect, sendMessage, addOnMessage, removeOnMessage, isConnected } =
+    useSocketStore();
   const shopId = localStorage.getItem("shopId") || "";
 
   // 대화 세션 ID (대화 시작할 때 1회 생성)
@@ -56,7 +57,7 @@ const Chat = () => {
   useEffect(() => {
     if (!isConnected) return;
 
-    setOnMessage(async (msg: SocketMessage) => {
+    const handle = async (msg: SocketMessage) => {
       switch (msg.type) {
         // CASE 7-1: 안내 음성 끝 → STT 시작
         case "END_GUIDE":
@@ -136,10 +137,17 @@ const Chat = () => {
         default:
           console.log("처리되지 않은 메시지:", msg);
       }
-    });
-
-    return () => setOnMessage(null); // 페이지 벗어나면 핸들러 해제
-  }, [isConnected, sendMessage, setOnMessage, shopId, sessionId]);
+    };
+    addOnMessage(handle);
+    return () => removeOnMessage(handle);
+  }, [
+    isConnected,
+    sendMessage,
+    shopId,
+    sessionId,
+    addOnMessage,
+    removeOnMessage,
+  ]);
 
   return (
     <BaseContainer>

--- a/src/page/Chat/Chat.tsx
+++ b/src/page/Chat/Chat.tsx
@@ -24,7 +24,11 @@ const Chat = () => {
   const [chatLogs, setChatLogs] = useState<ChatMessage[]>([]);
   const [isListening, setIsListening] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
-
+  //채팅 쌓였을 시 맨 하단부로 스크롤 기능 구현
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" }); // 새로운 메시지가 추가될 때마다 맨 아래로 이동
+  }, [chatLogs]);
   // 채팅 animation 기능
   const [visibleTexts, setVisibleTexts] = useState<Record<number, string>>({});
   useEffect(() => {
@@ -188,6 +192,7 @@ const Chat = () => {
               </ChatWrapper>
             );
           })}
+          <div ref={bottomRef} />
         </ChatContainer>
       </Background>
     </BaseContainer>
@@ -220,6 +225,10 @@ const ChatContainer = styled.div`
   margin: 1rem;
   border-radius: 20px;
   box-shadow: 0 5px 30px rgba(0, 0, 0, 0.1);
+
+  //채팅 쌓일 시 하단 채팅으로 이동했을 때 자연스럽게 이동하기 위한 css
+  padding-bottom: 80px;
+  scroll-padding-bottom: 80px;
   &::-webkit-scrollbar {
     width: 6px;
   }

--- a/src/page/Chat/ChatTestButton.tsx
+++ b/src/page/Chat/ChatTestButton.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react";
+import { ChatMessage } from "./Chat";
+import styled from "styled-components";
+interface ChatTestButtonProps {
+  setChatLogs: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+}
+
+const ChatTestButton = ({ setChatLogs }: ChatTestButtonProps) => {
+  //채팅 테스트 버튼
+  const [viewTestButton, setViewTestButton] = useState(false);
+
+  useEffect(() => {
+    window.showButton = (mode: boolean) => {
+      setViewTestButton(mode);
+    };
+  }, [viewTestButton]);
+  if (!viewTestButton) return;
+  return (
+    <BaseContainer>
+      <button
+        onClick={() => {
+          setChatLogs((prev) => [
+            ...prev,
+            { message: "봇 대화추가 ~", isBot: true },
+          ]);
+        }}
+      >
+        봇 대화 추가
+      </button>
+
+      <button
+        onClick={() => {
+          setChatLogs((prev) => [
+            ...prev,
+            { message: "사용자 대화추가 ~", isBot: false },
+          ]);
+        }}
+      >
+        사용자 대화 추가
+      </button>
+      <button
+        onClick={() => {
+          // 짧은 간격으로 여러 메시지를 추가해버림
+          setChatLogs((prev) => [
+            ...prev,
+            {
+              message:
+                "첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.",
+              isBot: true,
+            },
+          ]);
+          setTimeout(() => {
+            setChatLogs((prev) => [
+              ...prev,
+              {
+                message:
+                  "두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.",
+                isBot: true,
+              },
+            ]);
+          }, 100);
+        }}
+      >
+        봇 대화 많이 추가
+      </button>
+      <button
+        onClick={() => {
+          // 짧은 간격으로 여러 메시지를 추가해버림
+          setChatLogs((prev) => [
+            ...prev,
+            {
+              message:
+                "첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.",
+              isBot: false,
+            },
+          ]);
+          setTimeout(() => {
+            setChatLogs((prev) => [
+              ...prev,
+              {
+                message:
+                  "두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.",
+                isBot: false,
+              },
+            ]);
+          }, 100);
+        }}
+      >
+        사용자 대화 많이 추가
+      </button>
+
+      <button
+        onClick={() => {
+          // 짧은 간격으로 여러 메시지를 추가해버림
+          setChatLogs((prev) => [
+            ...prev,
+            {
+              message:
+                "첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.첫 번째 봇 메시지입니다.",
+              isBot: false,
+            },
+          ]);
+          setTimeout(() => {
+            setChatLogs((prev) => [
+              ...prev,
+              {
+                message:
+                  "두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.두 번째 봇 메시지입니다.",
+                isBot: true,
+              },
+            ]);
+          }, 100);
+        }}
+      >
+        주고받기 대화 많이 추가
+      </button>
+    </BaseContainer>
+  );
+};
+
+export default ChatTestButton;
+
+const BaseContainer = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 16px;
+`;

--- a/src/page/StartScreen/StartPage.tsx
+++ b/src/page/StartScreen/StartPage.tsx
@@ -4,14 +4,15 @@ import { useNavigate } from "react-router-dom";
 
 import { useEffect, useRef, useState } from "react";
 import { setShopData } from "../../apis/setShopData";
-import { useSocketStore } from "../../stores/socketStore";
+import { SocketMessage, useSocketStore } from "../../stores/socketStore";
 interface StyledProps {
   $isHovering?: boolean;
   $progress?: number;
 }
 const StartPge = () => {
   const { logoimg, name, startBackground } = useShopStore();
-  const { connect, sendMessage, setOnMessage, isConnected } = useSocketStore();
+  const { connect, sendMessage, addOnMessage, removeOnMessage, isConnected } =
+    useSocketStore();
   const nav = useNavigate();
   //소켓 관련
 
@@ -25,15 +26,15 @@ const StartPge = () => {
     sendMessage({ type: "MODE_SELECT_ON" }); //CASE 4
 
     //CASE 5-1
-    setOnMessage((msg) => {
+    const handle = (msg: SocketMessage) => {
       if (msg.type === "CHAT_ORDER_ON") {
         nav("/chat");
         sendMessage({ type: "CHAT_ORDER_ON" }); //CASE 5-2
       }
-    });
-
-    return () => setOnMessage(null);
-  }, [isConnected, nav, sendMessage, setOnMessage]);
+    };
+    addOnMessage(handle);
+    return () => removeOnMessage(handle);
+  }, [isConnected, nav, sendMessage, addOnMessage, removeOnMessage]);
 
   //새로고침 하더라도 shopData 유지
   useEffect(() => {

--- a/src/stores/socketStore.ts
+++ b/src/stores/socketStore.ts
@@ -92,18 +92,13 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 }));
 
 if (typeof window !== "undefined") {
-  (window as any).sendMessage = (msg: string | SocketMessage) => {
+  (window as any).sendMessage = (msg: SocketMessage) => {
     const handlers = useSocketStore.getState().handlers;
     if (!handlers.length) {
       console.warn("onMessageHandler가 아직 설정되지 않았습니다.");
       return;
     }
     console.log("sendMessage 호출됨:", msg);
-
-    // 문자열로 넣으면 {type: "TEST", message: "..."}로 변환
-    const socketMsg: SocketMessage =
-      typeof msg === "string" ? { type: "TEST", message: msg } : msg;
-
-    handlers.forEach((h) => h(socketMsg));
+    handlers.forEach((h) => h(msg));
   };
 }

--- a/src/stores/socketStore.ts
+++ b/src/stores/socketStore.ts
@@ -13,15 +13,17 @@ interface SocketState {
 
   connect: () => void;
   sendMessage: (msg: SocketMessage) => void;
-  setOnMessage: (handler: ((msg: SocketMessage) => void) | null) => void;
-  onMessageHandler: ((msg: SocketMessage) => void) | null;
+  addOnMessage: (handler: (msg: SocketMessage) => void) => void;
+  removeOnMessage: (handler: (msg: SocketMessage) => void) => void;
+  handlers: ((msg: SocketMessage) => void)[];
 }
 
 export const useSocketStore = create<SocketState>((set, get) => ({
   socket: null,
   isConnected: false,
   retryCount: 0,
-  maxRetries: 3, // 최대 재시도 횟수
+  maxRetries: 3, //최대 재시도 횟수
+  handlers: [],
 
   connect: () => {
     const { socket, retryCount, maxRetries } = get();
@@ -40,8 +42,11 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     };
 
     ws.onmessage = (event) => {
-      const handler = get().onMessageHandler;
-      if (handler) handler(JSON.parse(event.data));
+      const { handlers } = get();
+      try {
+        const msg = JSON.parse(event.data);
+        handlers.forEach((h) => h(msg));
+      } catch (_) {}
     };
 
     ws.onerror = (err) => {
@@ -77,17 +82,19 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     }
   },
 
-  setOnMessage: (handler) => {
-    set({ onMessageHandler: handler });
-  },
+  addOnMessage: (handler) =>
+    set((state) => ({ handlers: [...state.handlers, handler] })),
 
-  onMessageHandler: null,
+  removeOnMessage: (handler) =>
+    set((state) => ({
+      handlers: state.handlers.filter((h) => h !== handler),
+    })),
 }));
 
 if (typeof window !== "undefined") {
   (window as any).sendMessage = (msg: string | SocketMessage) => {
-    const handler = useSocketStore.getState().onMessageHandler;
-    if (!handler) {
+    const handlers = useSocketStore.getState().handlers;
+    if (!handlers.length) {
       console.warn("onMessageHandler가 아직 설정되지 않았습니다.");
       return;
     }
@@ -97,6 +104,6 @@ if (typeof window !== "undefined") {
     const socketMsg: SocketMessage =
       typeof msg === "string" ? { type: "TEST", message: msg } : msg;
 
-    handler(socketMsg);
+    handlers.forEach((h) => h(socketMsg));
   };
 }


### PR DESCRIPTION
# fix(#48): 소켓 통신 케이스 수정/ 조정 페이지/ 채팅 페이지 디테일 디벨롭

- 소켓 오류 수정을 위한 브랜치
- 소켓 핸들러 전면 개편(기존 1개의 핸들러 => 다중 핸들러 [ ]로 변경)


## 작업내용
- 소켓 기존 1개의 핸들러 => 다중 핸들러 [ ]로 변경)
- CASE 2 재점검

### ChatPage
- 채팅 페이지 window.showButton(true)를 통해 테스트 버튼 추가
- 채팅 애니메이션 버그 해결 (단일 state -> Record로 변경)
- 채팅 하단부 Ref추가



## 관련이슈

Closes #48
